### PR TITLE
Consistency for net strings.

### DIFF
--- a/lua/schat/cl_interface.lua
+++ b/lua/schat/cl_interface.lua
@@ -446,7 +446,7 @@ local schatClose = function()
 	hook.Run('FinishChat')
 	hook.Run('ChatTextChanged', '')
 
-	net.Start('schat.istyping', false)
+	net.Start('schat.is_typing', false)
 	net.WriteBool(false)
 	net.SendToServer()
 end
@@ -485,7 +485,7 @@ local schatOpen = function()
 	-- make sure other addons know we are chatting
 	hook.Run('StartChat')
 
-	net.Start('schat.istyping', false)
+	net.Start('schat.is_typing', false)
 	net.WriteBool(true)
 	net.SendToServer()
 end

--- a/lua/schat/sv_main.lua
+++ b/lua/schat/sv_main.lua
@@ -4,7 +4,7 @@
 resource.AddWorkshop('2799307109')
 
 util.AddNetworkString('schat.say')
-util.AddNetworkString('schat.istyping')
+util.AddNetworkString('schat.is_typing')
 
 util.AddNetworkString('schat.set_theme')
 util.AddNetworkString('schat.set_emojis')
@@ -80,7 +80,7 @@ function PLY:IsTyping()
 	return self:GetNWBool('IsTyping', false)
 end
 
-net.Receive('schat.istyping', function(_, ply)
+net.Receive('schat.is_typing', function(_, ply)
 	ply:SetNWBool('IsTyping', net.ReadBool())
 end)
 


### PR DESCRIPTION
Edited `util.AddNetworkString('schat.istyping')` to `util.AddNetworkString('schat.is_typing')` to make it more consistent with others strings.

```lua
util.AddNetworkString('schat.say')
util.AddNetworkString('schat.istyping') -- Uh...

util.AddNetworkString('schat.set_theme') -- Snake Case.
util.AddNetworkString('schat.set_emojis') -- Snake Case.
```