### PR TITLE
Add theme option to toggle avatars

### DIFF
--- a/lua/custom_chat/client/block_types.lua
+++ b/lua/custom_chat/client/block_types.lua
@@ -43,7 +43,7 @@ end
 blockTypes["player"] = function( panel, data, color, font )
     local lines = {}
 
-    if not data.isBot then
+    if not data.isBot and panel.displayAvatars then
         lines[#lines + 1] = panel:CreateImage( panel:FetchUserAvatarURL( data.id64 ), nil, "avatar ply-" .. data.id64 )
     end
 
@@ -78,7 +78,10 @@ blockTypes["player"] = function( panel, data, color, font )
 
     if color and color ~= color_white then
         AddLine( lines, "elPlayer.style.color = '%s';", RGBToJs( color ) )
-        AddLine( lines, "elImg.style['border-color'] = '%s';", RGBToJs( color ) )
+
+        if panel.displayAvatars then
+            AddLine( lines, "elImg.style['border-color'] = '%s';", RGBToJs( color ) )
+        end
     end
 
     return table.concat( lines, "\n" )

--- a/lua/custom_chat/client/theme.lua
+++ b/lua/custom_chat/client/theme.lua
@@ -23,6 +23,7 @@ function Theme.GetDefaultTheme()
         font = Theme.fonts[1],
         font_shadow = true,
         animate = true,
+        avatars = true,
         blur = 4,
         corner_radius = 8,
         padding = 8,
@@ -74,6 +75,7 @@ function Theme.ParseTheme( data, themeTable )
 
     SetBool( themeTable, "enableFontShadow", data.font_shadow )
     SetBool( themeTable, "enableSlideAnimation", data.animate )
+    SetBool( themeTable, "enableAvatars", data.avatars )
 
     SetNumber( themeTable, "backgroundBlur", data.blur, 0, 8 )
     SetNumber( themeTable, "cornerRadius", data.corner_radius, 0, 32 )

--- a/lua/custom_chat/client/vgui/chat_frame.lua
+++ b/lua/custom_chat/client/vgui/chat_frame.lua
@@ -203,6 +203,7 @@ function PANEL:LoadThemeData( data )
     self.history:SetDefaultFont( self.fontName )
     self.history:SetFontShadowEnabled( self.enableFontShadow )
     self.history:SetEnableAnimations( self.enableSlideAnimation )
+    self.history:SetEnableAvatars( self.enableAvatars )
 
     self.history:SetBackgroundColor( self.inputBackgroundColor )
     self.history:SetScrollBarColor( self.scrollBarColor )

--- a/lua/custom_chat/client/vgui/chat_history.lua
+++ b/lua/custom_chat/client/vgui/chat_history.lua
@@ -521,6 +521,7 @@ function PANEL:Init()
 
     self.animateMessages = true
     self.animationCooldown = 0
+    self.displayAvatars = true
 
     -- the main element that represents a single message,
     -- and is the parent for all of it's blocks
@@ -622,6 +623,10 @@ end
 
 function PANEL:SetEnableAnimations( enable )
     self.animateMessages = enable
+end
+
+function PANEL:SetEnableAvatars( enable )
+    self.displayAvatars = enable
 end
 
 function PANEL:SetDefaultFont( fontName )

--- a/lua/custom_chat/client/vgui/theme_editor.lua
+++ b/lua/custom_chat/client/vgui/theme_editor.lua
@@ -105,6 +105,16 @@ function PANEL:Init()
         self:ValueChanged( "animate", self.enableSlideAnimation )
     end
 
+    -- Player Avatars
+    self.playerAvatars = AddProperty( "theme.avatars", "DButton", panelProperties )
+    self.playerAvatars:SetText( L"theme.avatars" )
+
+    self.playerAvatars.DoClick = function()
+        self.enableAvatars = not self.enableAvatars
+        self.playerAvatars:SetIcon( self.enableAvatars and "icon16/accept.png" or "icon16/cross.png" )
+        self:ValueChanged( "avatars", self.enableAvatars )
+    end
+
     -- Background Blur
     self.sliderBlur = AddProperty( "theme.bg_blur", "DNumSlider", panelProperties )
     self.sliderBlur:SetText( L"theme.bg_blur" )
@@ -195,6 +205,7 @@ function PANEL:LoadThemeData( data )
 
     self.buttonFontShadow:SetIcon( self.enableFontShadow and "icon16/accept.png" or "icon16/cross.png" )
     self.buttonSlideAnimation:SetIcon( self.enableSlideAnimation and "icon16/accept.png" or "icon16/cross.png" )
+    self.playerAvatars:SetIcon( self.enableAvatars and "icon16/accept.png" or "icon16/cross.png" )
 
     self.sliderBlur:SetValue( self.backgroundBlur )
     self.sliderCorner:SetValue( self.cornerRadius )
@@ -223,6 +234,7 @@ function PANEL:SetDisabled( disabled )
     self.comboFont:SetDisabled( disabled )
     self.buttonFontShadow:SetDisabled( disabled )
     self.buttonSlideAnimation:SetDisabled( disabled )
+    self.playerAvatars:SetDisabled( disabled )
 
     self.sliderBlur:SetEnabled( not disabled )
     self.sliderCorner:SetEnabled( not disabled )

--- a/resource/localization/en/custom_chat.properties
+++ b/resource/localization/en/custom_chat.properties
@@ -119,6 +119,7 @@ custom_chat.theme.font_custom_item=<Custom>
 custom_chat.theme.font_custom_name=Please enter the desired font name.
 custom_chat.theme.font_shadow=Font Shadow
 custom_chat.theme.slide_animation=Slide-in Animation
+custom_chat.theme.avatars=Player Avatars
 custom_chat.theme.bg_blur=Background Blur
 custom_chat.theme.corner_radius=Corner Radius
 custom_chat.theme.padding=Padding


### PR DESCRIPTION
This adds a new theme option to toggle the presence of player avatars in new chat messages. This setting remains on by default in order to maintain the current behavior.

**Potential Issues**
- This currently only adds a localization string for English, as I don't speak either of the other translated languages.
- Toggling the option does not currently toggle the presence of existing avatars in the chat history. I'm not entirely sure how to approach this since I'm not well-versed in JS.