### PR TITLE
Add bot join leave messages toggle

### DIFF
--- a/lua/custom_chat/client/join_leave.lua
+++ b/lua/custom_chat/client/join_leave.lua
@@ -8,7 +8,9 @@ local JoinLeave = CustomChat.JoinLeave or {
 
     leaveColor = { 244, 144, 12 },
     leavePrefix = ":small_orange_diamond:",
-    leaveSuffix = "left!"
+    leaveSuffix = "left!",
+
+    botConnectDisconnect = false,
 }
 
 CustomChat.JoinLeave = JoinLeave
@@ -23,6 +25,8 @@ hook.Add( "player_connect_client", "CustomChat.ShowConnectMessages", function( d
     local name = data.name
     local steamId = data.networkid
     local isBot = data.bot == 1
+
+    if (isBot and (not JoinLeave.botConnectDisconnect)) then return end
 
     -- Only use a player block if Custom Chat is enabled
     if CustomChat.IsEnabled() then
@@ -53,6 +57,8 @@ hook.Add( "player_disconnect", "CustomChat.ShowDisconnectMessages", function( da
     local steamId = data.networkid
     local isBot = data.bot == 1
 
+    if (isBot and (not JoinLeave.botConnectDisconnect)) then return end
+
     -- Only use a player block if Custom Chat is enabled
     if CustomChat.IsEnabled() then
         name = {
@@ -76,6 +82,8 @@ hook.Add( "player_disconnect", "CustomChat.ShowDisconnectMessages", function( da
 end, HOOK_LOW )
 
 local function OnPlayerActivated( ply, steamId, name, color, absenceLength )
+    if (ply:IsBot() and (not JoinLeave.botConnectDisconnect)) then return end
+
     -- Only use a player block if Custom Chat is enabled
     if CustomChat.IsEnabled() then
         name = {

--- a/lua/custom_chat/client/main.lua
+++ b/lua/custom_chat/client/main.lua
@@ -476,7 +476,7 @@ end
 local function CustomChat_OnChatText( _, _, text, textType )
     if textType == "chat" then return end
 
-    local canShowJoinLeave = not ( CustomChat.JoinLeave.showConnect or CustomChat.JoinLeave.showDisconnect )
+    local canShowJoinLeave = not ( CustomChat.JoinLeave.showConnect or CustomChat.JoinLeave.showDisconnect)
     if not canShowJoinLeave and textType == "joinleave" then return end
 
     CustomChat:AddMessage( { Color( 0, 128, 255 ), text } )
@@ -657,6 +657,8 @@ hook.Add( "NetPrefs_OnChange", "CustomChat.OnServerConfigChange", function( key,
         JoinLeave.leaveColor = data.connection.leaveColor
         JoinLeave.leavePrefix = data.connection.leavePrefix
         JoinLeave.leaveSuffix = data.connection.leaveSuffix
+
+        JoinLeave.botConnectDisconnect = data.connection.botConnectDisconnect
     end
 end )
 

--- a/lua/custom_chat/client/tags.lua
+++ b/lua/custom_chat/client/tags.lua
@@ -281,6 +281,18 @@ function Tags:OpenEditor()
     panelConnectionTags:SetPaintBackground( false )
     sheet:AddSheet( L"tab.conn_disconn", panelConnectionTags, "icon16/group_go.png" )
 
+    local checkBotJoinLeave = vgui.Create( "DCheckBoxLabel", panelConnectionTags )
+    checkBotJoinLeave:SetText( L"tags.show_bot_joinleave_messages" )
+    checkBotJoinLeave:SetTextColor( Color( 255, 255, 255 ) )
+    checkBotJoinLeave:SetValue( byConnection.botConnectDisconnect )
+    checkBotJoinLeave:SizeToContents()
+    checkBotJoinLeave:Dock( TOP )
+    checkBotJoinLeave:DockPadding( 6, 6, 6, 6 )
+
+    checkBotJoinLeave.OnChange = function( _, val )
+        byConnection.botConnectDisconnect = val
+    end
+
     -- Connect messages
     local panelConnect = vgui.Create( "DPanel", panelConnectionTags )
     panelConnect:Dock( LEFT )

--- a/resource/localization/en/custom_chat.properties
+++ b/resource/localization/en/custom_chat.properties
@@ -77,6 +77,7 @@ custom_chat.tags.leave_suffix=Leave suffix
 custom_chat.tags.leave_color=Disconnected player color
 custom_chat.tags.apply=Apply all changes
 custom_chat.tags.apply_query=This action will apply the chat tags and join/leave messages to this server. Are you sure?
+custom_chat.tags.show_bot_joinleave_messages=Show Bots Join/Leave messages
 custom_chat.emojis.title=Server Emojis
 custom_chat.emojis.invalid=Invalid Emoji
 custom_chat.emojis.invalid_reason=Invalid emoji (%d): %s


### PR DESCRIPTION
- Add a toggle in Custom Tags window (Join/Leave messages tab)

To disable bots leave/join messages (ONLY when custom join or leave is enabled)
for default join or leave messages, bot join/leave messages are not suppressed

Last seen message is suppressed by this toggle
