### PR TITLE
Add check for Wiremod Keyboard hook

### DIFF
--- a/lua/custom_chat/client/main.lua
+++ b/lua/custom_chat/client/main.lua
@@ -500,8 +500,9 @@ local function CustomChat_OnPlayerBindPress( _, bind, pressed )
     -- Don't open if playable piano is blocking input
     if IsValid( LocalPlayer().Instrument ) then return end
 
-    -- Don't open if Starfall is blocking input
+    -- Don't open if Wiremod or Starfall is blocking input
     local existingBindHooks = hook.GetTable()["PlayerBindPress"]
+    if existingBindHooks["wire_keyboard_blockinput"] then return end
     if existingBindHooks["sf_keyboard_blockinput"] then return end
 
     -- Don't open if anything else wants to block input


### PR DESCRIPTION
Fixes the chatbox being able to open while typing on a Wiremod Keyboard. [wire_keyboard_blockinput](https://github.com/wiremod/wire/blob/ee7e76e4e3f5da6c1ddc8f0b755946ed96e1a474/lua/entities/gmod_wire_keyboard/cl_init.lua#L9-L18)