### PR TITLE
Absence cvar

### DIFF
--- a/lua/autorun/sh_custom_chat.lua
+++ b/lua/autorun/sh_custom_chat.lua
@@ -64,6 +64,9 @@ CreateConVar( "custom_chat_max_lines", "6", bit.bor( FCVAR_ARCHIVE, FCVAR_REPLIC
 CreateConVar( "custom_chat_enable_absence_messages", "1", bit.bor( FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY ),
     "On first spawn, show messages about when a player was last present on the server.", 0, 1 )
 
+CreateConVar( "custom_chat_absence_mintime", "300", bit.bor( FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY ),
+    "Minimum time in seconds to show absence messages. Set to 0 to disable.", 0 )
+
 CreateConVar( "custom_chat_enable_friend_messages", "1", bit.bor( FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_NOTIFY ),
     "Show messages to players when their friends spawn on the server.", 0, 1 )
 

--- a/lua/custom_chat/client/join_leave.lua
+++ b/lua/custom_chat/client/join_leave.lua
@@ -82,7 +82,7 @@ hook.Add( "player_disconnect", "CustomChat.ShowDisconnectMessages", function( da
 end, HOOK_LOW )
 
 local function OnPlayerActivated( ply, steamId, name, color, absenceLength )
-    --if ply:IsBot() and not JoinLeave.botConnectDisconnect then return end
+    if ply:IsBot() and not JoinLeave.botConnectDisconnect then return end
 
     -- Only use a player block if Custom Chat is enabled
     if CustomChat.IsEnabled() then

--- a/lua/custom_chat/client/join_leave.lua
+++ b/lua/custom_chat/client/join_leave.lua
@@ -82,7 +82,7 @@ hook.Add( "player_disconnect", "CustomChat.ShowDisconnectMessages", function( da
 end, HOOK_LOW )
 
 local function OnPlayerActivated( ply, steamId, name, color, absenceLength )
-    if ply:IsBot() and not JoinLeave.botConnectDisconnect then return end
+    --if ply:IsBot() and not JoinLeave.botConnectDisconnect then return end
 
     -- Only use a player block if Custom Chat is enabled
     if CustomChat.IsEnabled() then
@@ -112,6 +112,9 @@ local function OnPlayerActivated( ply, steamId, name, color, absenceLength )
 
     if absenceLength < 1 then return end
     if CustomChat.GetConVarInt( "enable_absence_messages", 0 ) == 0 then return end
+
+    local minTime = CustomChat.GetConVarInt( "absence_mintime", 0 )
+    if minTime > 0 and absenceLength < minTime then return end
 
     -- Show the last time the server saw this player
     local lastSeenTime = CustomChat.NiceTime( math.Round( absenceLength ) )

--- a/lua/custom_chat/client/main.lua
+++ b/lua/custom_chat/client/main.lua
@@ -32,15 +32,20 @@ function CustomChat.GetLanguageText( id )
     return language.GetPhrase( "custom_chat." .. id )
 end
 
+local year = 60 * 60 * 24 * 365
+local month = 60 * 60 * 24 * 30
+local day = 60 * 60 * 24
+local hour = 60 * 60
+local minute = 60
 function CustomChat.NiceTime( time )
     local L = CustomChat.GetLanguageText
 
     local timeUnits = {
-        { value = math.floor( time / ( 60 * 60 * 24 * 30 * 12 ) ), name = "time.years" },
-        { value = math.floor( time / ( 60 * 60 * 24 * 30 ) ) % 12, name = "time.months" },
-        { value = math.floor( time / ( 60 * 60 * 24 ) ) % 30, name = "time.days" },
-        { value = math.floor( time / ( 60 * 60 ) ) % 24, name = "time.hours" },
-        { value = math.floor( time / 60 ) % 60, name = "time.minutes" },
+        { value = math.floor( time / year ), name = "time.years" },
+        { value = math.floor( time / month ) % 12, name = "time.months" },
+        { value = math.floor( time / day ) % 30, name = "time.days" },
+        { value = math.floor( time / hour ) % 24, name = "time.hours" },
+        { value = math.floor( time / minute ) % 60, name = "time.minutes" },
         { value = time % 60, name = "time.seconds" }
     }
 
@@ -52,7 +57,11 @@ function CustomChat.NiceTime( time )
     end
 
     local selectedUnits = {}
-    for i = 1, math.min( 2, #nonZeroUnits ) do
+    local unitsToShow = 1
+    if time > month then
+        unitsToShow = 2
+    end
+    for i = 1, math.min( unitsToShow, #nonZeroUnits ) do
         table.insert( selectedUnits, nonZeroUnits[i] )
     end
 


### PR DESCRIPTION
Adds `custom_chat_absence_mintime` which defaults to 5 minutes, when switching maps players often trigger the absence thing especially on gamemodes that change maps often this gets pretty spammy.

Also made the `CustomChat.NiceTime` function only show the second time unit when we're above a month in time as for example `10 days, 2 hours` or `12 hours, 5 minutes` isn't really needed.