### PR TITLE
Klipy whitelist

### DIFF
--- a/lua/custom_chat/client/whitelist.lua
+++ b/lua/custom_chat/client/whitelist.lua
@@ -99,7 +99,8 @@ local whitelist = {
     pattern [[[%w-_]-%.tenor%.com/.+]],
 
     -- Klipy
-    simple [[static.klipy.com]],
+    simple [[klipy.com]],
+    pattern [[([%w-_]+)%.klipy%.com/(.+)]],
 
     -- Youtube
     simple [[youtu.be]],

--- a/lua/custom_chat/client/whitelist.lua
+++ b/lua/custom_chat/client/whitelist.lua
@@ -98,6 +98,9 @@ local whitelist = {
     simple [[tenor.com]],
     pattern [[[%w-_]-%.tenor%.com/.+]],
 
+    -- Klipy
+    simple [[static.klipy.com]],
+
     -- Youtube
     simple [[youtu.be]],
     pattern [[([%w-_]+)%.youtube%.com/(.+)]],


### PR DESCRIPTION
Adds support for the new image service discord uses, they stopped using tenor and went to klipy.