### PR TITLE
Add fallback for map transitions

### DIFF
--- a/lua/custom_chat/server/player_spawn.lua
+++ b/lua/custom_chat/server/player_spawn.lua
@@ -13,6 +13,7 @@ hook.Add( "player_disconnect", "CustomChat.TrackDisconnectingPlayers", function(
     connectingSteamIDs[steamId] = nil
 end )
 
+local serverStartTime = SysTime()
 hook.Add( "PlayerInitialSpawn", "CustomChat.BroadcastInitialSpawn", function( ply )
     -- Give some time for other addons to assign the team
     timer.Simple( 3, function()
@@ -35,6 +36,8 @@ hook.Add( "PlayerInitialSpawn", "CustomChat.BroadcastInitialSpawn", function( pl
         if connectingSteamIDs[steamId] then
             local connectTime = connectingSteamIDs[steamId]
             timeToSpawn = SysTime() - connectTime
+        else -- needed for when a player joins from a map transition as they wont trigger the player_connect event.
+            timeToSpawn = SysTime() - serverStartTime
         end
 
         net.Start( "customchat.player_spawned", false )


### PR DESCRIPTION
Currently it'd show 0 if people came back from a map change, now it'll show proper timing